### PR TITLE
Use nix shebang to fix mac problems and resolve cabal2nix dependency

### DIFF
--- a/cabal2nix4dev
+++ b/cabal2nix4dev
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p cabal2nix
 # <http://redsymbol.net/articles/unofficial-bash-strict-mode/>
 set -euo pipefail
 IFS=$'\n\t'

--- a/cabal2nix4dev
+++ b/cabal2nix4dev
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p cabal2nix
+#!nix-shell --pure -i bash -p cabal2nix perl
 # <http://redsymbol.net/articles/unofficial-bash-strict-mode/>
 set -euo pipefail
 IFS=$'\n\t'


### PR DESCRIPTION
If we use a nix shebang like this, the script only depends on nix being install and will work the same on all environments.

```
#!/usr/bin/env nix-shell
#!nix-shell --pure -i bash -p cabal2nix perl
```

Fixes #2 